### PR TITLE
attempt to fix ordering

### DIFF
--- a/nexusutils/dataconverter/convert.py
+++ b/nexusutils/dataconverter/convert.py
@@ -53,7 +53,7 @@ def get_reader(reader_name) -> BaseReader:
 def get_names_of_all_readers() -> List[str]:
     """Helper function to populate a list of all available readers"""
     path_prefix = f"{os.path.dirname(__file__)}{os.sep}" if os.path.dirname(__file__) else ""
-    files = glob.glob(os.path.join(path_prefix, "readers", "*", "reader.py"))
+    files = sorted(glob.glob(os.path.join(path_prefix, "readers", "*", "reader.py")))
     all_readers = []
     for file in files:
         if f"{os.sep}base{os.sep}" not in file:

--- a/nexusutils/nexus/nexus.py
+++ b/nexusutils/nexus/nexus.py
@@ -103,11 +103,11 @@ def get_nx_classes():
 Check each file in base_classes, applications, contributed_definitions.
 If its category attribute is 'base', then it is added to the list. """
     base_classes = sorted(glob(os.path.join(get_nexus_definitions_path(),
-                                     'base_classes', '*.nxdl.xml')))
+                               'base_classes', '*.nxdl.xml')))
     applications = sorted(glob(os.path.join(get_nexus_definitions_path(),
-                                     'applications', '*.nxdl.xml')))
+                               'applications', '*.nxdl.xml')))
     contributed = sorted(glob(os.path.join(get_nexus_definitions_path(),
-                                    'contributed_definitions', '*.nxdl.xml')))
+                              'contributed_definitions', '*.nxdl.xml')))
     nx_clss = []
     for nexus_file in base_classes + applications + contributed:
         tree = ET.parse(nexus_file)

--- a/nexusutils/nexus/nexus.py
+++ b/nexusutils/nexus/nexus.py
@@ -20,7 +20,7 @@ def get_app_defs_names():
     app_def_path_glob = f"{get_nexus_definitions_path()}{os.sep}applications{os.sep}*.nxdl*"
     contrib_def_path_glob = (f"{get_nexus_definitions_path()}{os.sep}"
                              f"contributed_definitions{os.sep}*.nxdl*")
-    files = glob(app_def_path_glob) + glob(contrib_def_path_glob)
+    files = sorted(glob(app_def_path_glob)) + sorted(glob(contrib_def_path_glob))
     return [os.path.basename(file).split(".")[0] for file in files] + ["NXroot"]
 
 
@@ -102,12 +102,12 @@ def get_nx_classes():
     """Read base classes from the NeXus definition folder.
 Check each file in base_classes, applications, contributed_definitions.
 If its category attribute is 'base', then it is added to the list. """
-    base_classes = glob(os.path.join(get_nexus_definitions_path(),
-                                     'base_classes', '*.nxdl.xml'))
-    applications = glob(os.path.join(get_nexus_definitions_path(),
-                                     'applications', '*.nxdl.xml'))
-    contributed = glob(os.path.join(get_nexus_definitions_path(),
-                                    'contributed_definitions', '*.nxdl.xml'))
+    base_classes = sorted(glob(os.path.join(get_nexus_definitions_path(),
+                                     'base_classes', '*.nxdl.xml')))
+    applications = sorted(glob(os.path.join(get_nexus_definitions_path(),
+                                     'applications', '*.nxdl.xml')))
+    contributed = sorted(glob(os.path.join(get_nexus_definitions_path(),
+                                    'contributed_definitions', '*.nxdl.xml')))
     nx_clss = []
     for nexus_file in base_classes + applications + contributed:
         tree = ET.parse(nexus_file)

--- a/tests/dataconverter/test_readers.py
+++ b/tests/dataconverter/test_readers.py
@@ -82,7 +82,9 @@ def test_has_correct_read_func(reader):
         def_dir = os.path.join(os.getcwd(), "nexusutils", "definitions")
         dataconverter_data_dir = os.path.join("tests", "data", "dataconverter")
 
-        input_files = sorted(glob.glob(os.path.join(dataconverter_data_dir, "readers", reader_name, "*")))
+        input_files = sorted(
+            glob.glob(os.path.join(dataconverter_data_dir, "readers", reader_name, "*"))
+        )
         for supported_nxdl in reader.supported_nxdls:
             if supported_nxdl in ("NXtest", "*"):
                 nxdl_file = os.path.join(dataconverter_data_dir, "NXtest.nxdl.xml")

--- a/tests/dataconverter/test_readers.py
+++ b/tests/dataconverter/test_readers.py
@@ -44,7 +44,7 @@ def get_reader_name_from_reader_object(reader) -> str:
 
 def get_readers_file_names() -> List[str]:
     """Helper function to parametrize paths of all the reader Python files"""
-    return glob.glob("nexusutils/dataconverter/readers/*/reader.py")
+    return sorted(glob.glob("nexusutils/dataconverter/readers/*/reader.py"))
 
 
 def get_all_readers() -> List[ParameterSet]:
@@ -82,7 +82,7 @@ def test_has_correct_read_func(reader):
         def_dir = os.path.join(os.getcwd(), "nexusutils", "definitions")
         dataconverter_data_dir = os.path.join("tests", "data", "dataconverter")
 
-        input_files = glob.glob(os.path.join(dataconverter_data_dir, "readers", reader_name, "*"))
+        input_files = sorted(glob.glob(os.path.join(dataconverter_data_dir, "readers", reader_name, "*")))
         for supported_nxdl in reader.supported_nxdls:
             if supported_nxdl in ("NXtest", "*"):
                 nxdl_file = os.path.join(dataconverter_data_dir, "NXtest.nxdl.xml")


### PR DESCRIPTION
The usage of glob function to load the files and which may return with an arbitrary order could cause random order in the generated metainfo file.

