### PR TITLE
Nyaml2nxdl comment preservation

### DIFF
--- a/nexusutils/dataconverter/helpers.py
+++ b/nexusutils/dataconverter/helpers.py
@@ -440,7 +440,10 @@ def validate_data_dict(template, data, nxdl_root: ET.Element):
 
 def remove_namespace_from_tag(tag):
     """Helper function to remove the namespace from an XML tag."""
-    return tag.split("}")[-1]
+    if '}' in tag:
+        return tag.split("}")[-1]
+    else:
+        return tag
 
 
 def get_first_group(root):

--- a/nexusutils/dataconverter/helpers.py
+++ b/nexusutils/dataconverter/helpers.py
@@ -440,10 +440,8 @@ def validate_data_dict(template, data, nxdl_root: ET.Element):
 
 def remove_namespace_from_tag(tag):
     """Helper function to remove the namespace from an XML tag."""
-    if '}' in tag:
-        return tag.split("}")[-1]
-    else:
-        return tag
+
+    return tag.split("}")[-1]
 
 
 def get_first_group(root):

--- a/nexusutils/nyaml2nxdl/comment_collector.py
+++ b/nexusutils/nyaml2nxdl/comment_collector.py
@@ -1,0 +1,329 @@
+from typing import List, Type, Any, Tuple, Union
+import xml.etree.ElementTree as ET
+from nyaml2nxdl_helper import nx_name_type_resolving, LineLoader
+
+__all__ = ['Comment', 'CommentCollector']
+
+
+class CommentCollector:
+    """CommentCollector will store a full comment ('Comment') object in
+    _comment_chain.
+    """
+
+    def __init__(self, input_file: str = None,
+                 loaded_file: object = None,
+                 file_ext: str = None):
+        """
+        """
+        self._comment_chain: List[Type[Comment]] = []
+        self._next_comment = None
+        self._next_comment_id = None
+        self.file = input_file
+
+        if self.file and not loaded_file:
+            if self.file.split('.')[-1] == 'xml':
+                self.Comment = XMLComment
+            if self.file.split('.')[-1] == 'yaml':
+                self.Comment = YAMLComment
+                with open(self.file, "r", encoding="utf-8") as plain_text_yaml:
+                    loader = LineLoader(plain_text_yaml)
+                    self.Comment.__yaml_dict__ = loader.get_single_data()
+
+        elif self.file and loaded_file:
+            if self.file.split('.')[-1] == 'yaml':
+                self.Comment = YAMLComment
+                self.Comment.__yaml_dict__ = loaded_file
+
+    def extract_all_comment_blocks(self):
+        """
+        """
+        id_ = 0
+        single_comment = self.Comment(comment_id=id_)
+        self._next_comment = single_comment
+        self._next_comment_id = single_comment.cid
+        with open(self.file, mode='r', encoding='UTF-8') as f:
+            lines = f.readlines()
+
+            for line_num, line in enumerate(lines):
+                if single_comment.is_storing_single_comment():
+                    # Line number in file starts from 1
+                    single_comment.process_each_line(line, (line_num + 1))
+                else:
+                    self._comment_chain.append(single_comment)
+                    single_comment = self.Comment(last_comment=single_comment)
+                    single_comment.process_each_line(line, (line_num + 1))
+
+    def get_comment(self):
+        comment = self._next_comment
+        return comment.get_comment()
+
+    def reload_next_comment(self):
+        comment = self._comment_chain[self._next_comment_id]
+
+        if comment.cid != self._next_comment_id:
+            raise ValueError(f"Somthing worng in comment order in "
+                             f"{self._next_comment.__name__}")
+        else:
+            self._next_comment_text = comment
+
+
+class Comment:
+    def __init__(self,
+                 comment_id: int = -1,
+                 last_comment: 'Comment' = None) -> None:
+        """Comment object can be considered as a block element that includes
+            document element (an entity for what the comment is written).
+        """
+        self._elemt: Any = None
+        self._elemt_text: str = None
+        self._is_elemt_found: bool = None
+        self._is_elemt_stored: bool = None
+
+        self._comnt: str = ''
+        # If Multiple comments for one element or entity
+        self._comnt_list: list[str] = []
+        self.last_comment: 'Comment' = last_comment if last_comment else None
+        if comment_id >= 0 and last_comment:
+            self.cid = comment_id
+            self.last_comment = last_comment
+        elif comment_id == 0 and not last_comment:
+            self.cid = comment_id
+            self.last_comment = None
+        elif last_comment:
+            self.cid: int = (self.last_comment.cid + 1)
+            self.last_comment = last_comment
+        else:
+            raise ValueError(f"Neither last comment nor comment id dound")
+        self._comnt_start_found: bool = False
+        self._comnt_end_found: bool = False
+        self.is_storing_single_comment = lambda: not (self._comnt_end_found and self._is_elemt_stored)
+        # TODO try to create a class level total comment and everytime update it
+        self.total_comments: int = None
+
+    def get_last_comment(self):
+        return self.last_comment
+
+    def get_comment_text(self) -> Union[List, str]:
+        self._comnt
+
+    def append_comment(self, text: str) -> None:
+        pass
+
+    def store_element(self, *keyargs) -> None:
+        pass
+
+
+class XMLComment(Comment):
+
+    def __init__(self, comment_id: int = -1, last_comment: 'Comment' = None) -> None:
+        super().__init__(comment_id, last_comment)
+
+    def process_each_line(self, text, line_num):
+        """Take care of each line of text. Through which function the text
+        must be passed should be decide here.
+        """
+        text = text.strip()
+        # TODO pass empty text as comment might contain empty line
+        if text:
+            self.append_comment(text)
+            if self._comnt_end_found and not self._is_elemt_found:
+                if self._comnt:
+                    self._comnt_list.append(self._comnt)
+                    self._comnt = ''
+
+            if self._comnt_end_found:
+                self.store_element(text)
+
+    def append_comment(self, text: str) -> None:
+        """
+        """
+
+        # Comment in single line
+        if '<!--' == text[0:4]:
+            self._comnt_start_found = True
+            self._comnt_end_found = False
+            self._comnt = self._comnt + text.replace('<!--', '')
+            if '-->' == text[-4:]:
+                self._comnt_end_found = True
+                self._comnt_start_found = False
+                self._comnt = self._comnt.replace('-->', '')
+
+        elif '-->' == text[0:4] and self._comnt_start_found:
+            self._comnt_end_found = True
+            self._comnt_start_found = False
+            self._comnt = self._comnt + '\n' + text.replace('-->', '')
+        elif self._comnt_start_found:
+            self._comnt = self._comnt + '\n' + text
+
+    def store_element(self, text: str) -> None:
+        """
+        """
+
+        def collect_xml_attributes(text_part):
+            for part in text_part:
+                part = part.strip()
+                if part and '">' == ''.join(part[-2:]):
+                    self._is_elemt_stored = True
+                    self._is_elemt_found = False
+                    part = ''.join(part[0:-2])
+                elif part and '"/>' == ''.join(part[-3:]):
+                    self._is_elemt_stored = True
+                    self._is_elemt_found = False
+                    part = ''.join(part[0:-3])
+                elif part and '/>' == ''.join(part[-2:]):
+                    self._is_elemt_stored = True
+                    self._is_elemt_found = False
+                    part = ''.join(part[0:-2])
+                elif part and '>' == part[-1]:
+                    self._is_elemt_stored = True
+                    self._is_elemt_found = False
+                    part = ''.join(part[0:-1])
+                elif part and '"' == part[-1]:
+                    part = ''.join(part[0:-1])
+
+                if '="' in part:
+                    lf_prt, rt_prt = part.split('="')
+                else:
+                    continue
+                if ':' in lf_prt:
+                    continue
+                self._elemt[lf_prt] = str(rt_prt)
+        if not self._elemt:
+            self._elemt = {}
+        # First check for comment part has been collected prefectly
+        if '</' == text[0:2]:
+            return
+        elif '<' == text[0] and not '<!--' == text[0:4]:
+            self._is_elemt_found = True
+            text = text.replace('<', '', 1)
+            text_part = text.split(' ')
+            # collect tag
+            self._elemt['tag'] = text_part[0]
+            self._elemt['attrib'] = {}
+            collect_xml_attributes(text_part[1:])
+
+        elif self._is_elemt_found:
+            text_part = text.split(' ')
+            collect_xml_attributes(text_part)
+
+    def get_element_info(self) -> dict:
+        """
+            The method returns info dict that includes:
+        'tag' and 'attrib' keys.
+        """
+        return self._elemt
+
+    def get_comment_text(self) -> Union[List, str]:
+        """
+            This method returns list of commnent text. As some xml element might have
+            multiple separated comment intended for a single element.
+        """
+        return self._comnt_list
+
+
+class YAMLComment(Comment):
+    """
+    """
+    # Class level variable. The main reason behind that to follow structure of
+    # abstract class 'Comment'
+    __yaml_dict__: dict = {}
+    __yaml_line_info__: dict = {}
+
+    def __init__(self, comment_id: int = -1, last_comment: 'Comment' = None) -> None:
+        super().__init__(comment_id, last_comment)
+        self.collect_yaml_line_info(self.__yaml_dict__, self.__yaml_line_info__)
+
+    def process_each_line(self, text, line_num):
+        """Take care of each line of text. Through which function the text
+        must be passed should be decide here.
+        """
+        text = text.strip()
+        self.append_comment(text)
+        if self._comnt_end_found and not self._is_elemt_found:
+            if self._comnt:
+                self._comnt_list.append(self._comnt)
+                self._comnt = ''
+
+        if self._comnt_end_found:
+            line_key = ''
+            if ':' in text:
+                ind = text.index(':')
+                line_key = '__line__' + ''.join(text[0:ind])
+
+            for l_num, l_key in self.__yaml_line_info__.items():
+                if line_num == int(l_num) and line_key == l_key:
+                    line_number = line_num
+                    self.store_element(line_key, line_number)
+                    break
+
+    def append_comment(self, text: str) -> None:
+        """
+        """
+        # Empty line after last line of comment
+        if not text and self._comnt_start_found:
+            self._comnt_end_found = True
+            self._comnt_start_found = False
+        # For empty line inside doc or yaml file.
+        elif not text:
+            return
+        # TODO: keep comment block with '#' do not replace that
+        elif '# ' == ''.join(text[0:2]):
+            self._comnt_start_found = True
+            self._comnt_end_found = False
+            self._comnt = '' if not self._comnt else self._comnt + '\n'
+            self._comnt = self._comnt + ''.join(text[2:])
+        elif '#' == text[0]:
+            self._comnt_start_found = True
+            self._comnt_end_found = False
+            self._comnt = '' if not self._comnt else self._comnt + '\n'
+            self._comnt = self._comnt + ''.join(text[2:])
+        # for any line after 'comment block' found
+        elif self._comnt_start_found:
+            self._comnt_start_found = False
+            self._comnt_end_found = True
+
+    def store_element(self, line_key: str, line_number: str):
+        """
+        """
+        self._elemt = {}
+        self._elemt[line_key] = line_number
+        self._is_elemt_found = False
+        self._is_elemt_stored = True
+
+    def get_comment_text(self):
+        return self._comnt_list
+
+    def get_element_location(self) -> Union[Tuple, None]:
+        """
+        """
+        if len(self._elemt) > 1:
+            raise ValueError(f"Comment element should be one but got "
+                             "{self._elemt}")
+
+        for key, val in self._elemt.items():
+            return key, val
+
+    # TODO Try to make this function static
+    # @staticmethod
+    def collect_yaml_line_info(self, yaml_dict, line_info_dict):
+        """Collect __line__key and corresponding value from
+        a yaml file dictonary in another dictionary.
+        """
+        for line_key, line_n in yaml_dict.items():
+            if '__line__' in line_key:
+                line_info_dict[line_n] = line_key
+
+        for _, val in yaml_dict.items():
+            if isinstance(val, dict):
+                self.collect_yaml_line_info(val, line_info_dict)
+
+
+if __name__ == "__main__":
+    file = ("/home/rubel/Nomad-FAIRmat/NomadGH/GH_Clone/nexus_definitions/base_classes"
+            "/NXdata.nxdl.xml")
+    collector = CommentCollector(file)
+    collector.extract_all_comment_blocks()
+
+    for comment in collector._comment_chain:
+        print('comment text : ', comment.get_comment_text())
+        print('comment line : ', comment.get_element_info(), '\n')

--- a/nexusutils/nyaml2nxdl/comment_collector.py
+++ b/nexusutils/nyaml2nxdl/comment_collector.py
@@ -330,12 +330,12 @@ class YAMLComment(Comment):
             self._comnt_start_found = True
             self._comnt_end_found = False
             self._comnt = '' if not self._comnt else self._comnt + '\n'
-            self._comnt = self._comnt + ''.join(text[2:])
+            self._comnt = self._comnt + text  # remove ''.join(text[2:])
         elif '#' == text[0]:
             self._comnt_start_found = True
             self._comnt_end_found = False
             self._comnt = '' if not self._comnt else self._comnt + '\n'
-            self._comnt = self._comnt + ''.join(text[1:])
+            self._comnt = self._comnt + text    # TODO: remove''.join(text[1:])
         # for any line after 'comment block' found
         elif self._comnt_start_found:
             self._comnt_start_found = False

--- a/nexusutils/nyaml2nxdl/comment_collector.py
+++ b/nexusutils/nyaml2nxdl/comment_collector.py
@@ -1,4 +1,7 @@
-from typing import List, Type, Any, Tuple, Union, Self
+"""
+"""
+
+from typing import List, Type, Any, Tuple, Union
 import xml.etree.ElementTree as ET
 from nexusutils.nyaml2nxdl.nyaml2nxdl_helper import nx_name_type_resolving, LineLoader
 
@@ -435,7 +438,7 @@ class YAMLComment(Comment):
         """For Checking whether __line__NAME is in _elemt dict or not."""
         return line_key in self._elemt
 
-    def __eq__(self, comment_obj: Self) -> bool:
+    def __eq__(self, comment_obj) -> bool:
         """Check the self has same value as right comment.
         """
         if len(self._comnt_list) != len(comment_obj._comnt_list):

--- a/nexusutils/nyaml2nxdl/comment_collector.py
+++ b/nexusutils/nyaml2nxdl/comment_collector.py
@@ -1,4 +1,4 @@
-from typing import List, Type, Any, Tuple, Union
+from typing import List, Type, Any, Tuple, Union, Self
 import xml.etree.ElementTree as ET
 from nexusutils.nyaml2nxdl.nyaml2nxdl_helper import nx_name_type_resolving, LineLoader
 
@@ -127,6 +127,11 @@ class CommentCollector:
         if ind >= len(self._comment_chain):
             raise IndexError(f'Oops! Coment index {ind} in {__class__} is out of range!')
         return self._comment_chain[ind]
+
+    def __iter__(self):
+        """get_comment_ieratively
+        """
+        return iter(self._comment_chain)
 
 
 class Comment:
@@ -394,10 +399,6 @@ class YAMLComment(Comment):
         for line_anno, line_loc in self._elemt.items():
             return line_anno, line_loc
 
-    def __contains__(self, line_key):
-        """For Checking whether __line__NAME is in _elemt dict or not."""
-        return line_key in self._elemt
-
     def replace_scape_char(self, text):
         """Replace escape char according to __comment_escape_char dict
         """
@@ -429,6 +430,23 @@ class YAMLComment(Comment):
         for _, val in yaml_dict.items():
             if isinstance(val, dict):
                 self.collect_yaml_line_info(val, line_info_dict)
+
+    def __contains__(self, line_key):
+        """For Checking whether __line__NAME is in _elemt dict or not."""
+        return line_key in self._elemt
+
+    def __eq__(self, comment_obj: Self) -> bool:
+        """Check the self has same value as right comment.
+        """
+        if len(self._comnt_list) != len(comment_obj._comnt_list):
+            return False
+        for left_cmnt, right_cmnt in zip(self._comnt_list, comment_obj._comnt_list):
+            left_cmnt = left_cmnt.split('\n')
+            right_cmnt = right_cmnt.split('\n')
+            for left_line, right_line in zip(left_cmnt, right_cmnt):
+                if left_line.strip() != right_line.strip():
+                    return False
+        return True
 
 
 if __name__ == "__main__":

--- a/nexusutils/nyaml2nxdl/comment_collector.py
+++ b/nexusutils/nyaml2nxdl/comment_collector.py
@@ -1,13 +1,4 @@
 #!usr/bin/env python3
-"""
-Collect comments in a list by comment collector class
-
-The class Comment block is an abstract class for general functions or method to be implemented
-XMLComment and YAMLComment class.
-
-NOTE: Here comment block mainly stands for (comment text + line or element for what comment is
-intended.)
-"""
 # -*- coding: utf-8 -*-
 #
 # Copyright The NOMAD Authors.
@@ -26,6 +17,19 @@ intended.)
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+"""
+Collect comments in a list by CommentCollector class. Comment is a instance of Comment,
+where each comment includes comment text and line info or neighbour info where the
+comment must be assinged.
+
+The class Comment is an abstract class for general functions or method to be implemented
+XMLComment and YAMLComment class.
+
+NOTE: Here comment block mainly stands for (comment text + line or element for what comment is
+intended.)
+"""
+
 
 from typing import List, Type, Any, Tuple, Union, Dict
 from nexusutils.nyaml2nxdl.nyaml2nxdl_helper import LineLoader
@@ -79,8 +83,9 @@ class CommentCollector:
         single_comment = self.comment(comment_id=id_)
         with open(self.file, mode='r', encoding='UTF-8') as enc_f:
             lines = enc_f.readlines()
-            # Make an empty line for last comment if no enpty lines in original file
-            lines.append('')
+            # Make an empty line for last comment if no empty lines in original file
+            if lines[-1] != '':
+                lines.append('')
             for line_num, line in enumerate(lines):
                 if single_comment.is_storing_single_comment():
                     # If the last comment comes without post nxdl fields, groups and attributes
@@ -143,14 +148,14 @@ class CommentCollector:
         return False
 
     def __getitem__(self, ind):
-        """Get comment from  self_obj._comment_chain by index.
+        """Get comment from  self.obj._comment_chain by index.
         """
         if ind >= len(self._comment_chain):
             raise IndexError(f'Oops! Coment index {ind} in {__class__} is out of range!')
         return self._comment_chain[ind]
 
     def __iter__(self):
-        """get_comment_ieratively
+        """get comment ieratively
         """
         return iter(self._comment_chain)
 
@@ -316,7 +321,8 @@ class XMLComment(Comment):
 
 class YAMLComment(Comment):
     """
-
+    This class for stroing comment text as well as location of the comment e.g. line
+    number of other in the file.
     NOTE:
      1. Do not delete any element form yaml dictionary (for loaded_obj. check: Comment_collector
      class. because this loaded file has been exploited in nyaml2nxdl forward tools.)

--- a/nexusutils/nyaml2nxdl/comment_collector.py
+++ b/nexusutils/nyaml2nxdl/comment_collector.py
@@ -90,7 +90,7 @@ class CommentCollector:
                 if single_comment.is_storing_single_comment():
                     # If the last comment comes without post nxdl fields, groups and attributes
                     if line_num < (len(lines) - 1):
-                        # Line number in file starts from 1
+                        # Processing file from Line number 1
                         single_comment.process_each_line(line, (line_num + 1))
                     else:
                         # For processing post comment

--- a/nexusutils/nyaml2nxdl/nyaml2nxdl_backward_tools.py
+++ b/nexusutils/nyaml2nxdl/nyaml2nxdl_backward_tools.py
@@ -45,7 +45,6 @@ def separate_pi_comments(input_file):
 
     with open(input_file, "r", encoding='utf-8') as file:
         lines = file.readlines()
-        # pi -> ProcessInstructio section
         has_pi = True
         for line in lines:
             c_start = '<!--'
@@ -218,10 +217,10 @@ class Nxdl2yaml():
                                 self.handle_not_root_level_doc(depth,
                                                                tag=child.attrib['name'],
                                                                text=symbol_doc.text))
-        self.strore_root_level_comments('symbol_doc_comments', sbl_doc_cmnt_list)
-        self.strore_root_level_comments('symbol_comments', symbol_cmnt_list)
+        self.stroe_root_level_comments('symbol_doc_comments', sbl_doc_cmnt_list)
+        self.stroe_root_level_comments('symbol_comments', symbol_cmnt_list)
 
-    def strore_root_level_comments(self, holder, comment):
+    def stroe_root_level_comments(self, holder, comment):
         """Store yaml text or section line and the comments inteded for that lines or section"""
 
         self.root_level_comment[holder] = comment
@@ -865,7 +864,7 @@ class Nxdl2yaml():
                         last_comment = self.comvert_to_ymal_comment(depth * DEPTH_SIZE, child.text)
                         remove_cmnt_n = child
                     if tag_tmp == 'doc':
-                        self.strore_root_level_comments('root_doc', last_comment)
+                        self.stroe_root_level_comments('root_doc', last_comment)
                         last_comment = ''
                         self.handle_root_level_doc(child)
                         node.remove(child)
@@ -873,7 +872,7 @@ class Nxdl2yaml():
                             node.remove(remove_cmnt_n)
                             remove_cmnt_n = None
                     if tag_tmp == 'symbols':
-                        self.strore_root_level_comments('symbols', last_comment)
+                        self.stroe_root_level_comments('symbols', last_comment)
                         last_comment = ''
                         self.handle_symbols(depth, child)
                         node.remove(child)

--- a/nexusutils/nyaml2nxdl/nyaml2nxdl_backward_tools.py
+++ b/nexusutils/nyaml2nxdl/nyaml2nxdl_backward_tools.py
@@ -316,7 +316,7 @@ class Nxdl2yaml():
                 tag = remove_namespace_from_tag(tag)
             indent = depth * DEPTH_SIZE
 
-        doc_str = f"{indent}{tag}: | {text}\n"
+        doc_str = f"{indent}{tag}: |{text}\n"
         if file_out:
             file_out.write(doc_str)
             return None
@@ -543,6 +543,7 @@ class Nxdl2yaml():
 
         dim_index_value = ''
         dim_other_parts = {}
+        dim_cmnt_node = []
         # taking care of dim and doc childs of dimension
         for child in list(node):
             tag = remove_namespace_from_tag(child.tag)
@@ -574,7 +575,16 @@ class Nxdl2yaml():
                         if attr not in dim_other_parts:
                             dim_other_parts[attr] = []
                         dim_other_parts[attr].append(value)
+            if tag == CMNT_TAG and self.include_comment:
+                # Store and remove node so that comment nodes from dim node so that it does not call in
+                # xmlparser function
+                dim_cmnt_node.append(child)
+                node.remove(child)
 
+        # All 'dim' element comments on top of 'dim' yaml key
+        if dim_cmnt_node:
+            for nd in dim_cmnt_node:
+                self.handel_comment(depth + 1, nd, file_out)
         # index and value attributes of dim elements
         file_out.write(
             '{indent}dim: [{value}]\n'.format(

--- a/nexusutils/nyaml2nxdl/nyaml2nxdl_forward_tools.py
+++ b/nexusutils/nyaml2nxdl/nyaml2nxdl_forward_tools.py
@@ -818,10 +818,10 @@ def xml_handle_fields(obj, keyword, value, line_annot, line_loc, verbose=False):
         recursive_build(elemt_obj, value, verbose)
 
 
-def xml_handle_comment(obj: ET,
+def xml_handle_comment(obj: ET.Element,
                        line_annotation: str,
                        line_loc_no: int,
-                       xml_ele: ET = None,
+                       xml_ele: ET.Element = None,
                        is_def_cmnt: bool = False):
     """
         Add xml comment: check for comments that has the same 'line_annotation'

--- a/nexusutils/nyaml2nxdl/nyaml2nxdl_helper.py
+++ b/nexusutils/nyaml2nxdl/nyaml2nxdl_helper.py
@@ -27,8 +27,43 @@ which details a hierarchy of data/metadata elements
 # Yaml library does not except the keys (escapechar "\t" and yaml separator ":")
 # So the corresponding value is to skip them and
 # and also carefull about this order
+from yaml.composer import Composer
+from yaml.constructor import Constructor
+
+from yaml.nodes import ScalarNode
+from yaml.resolver import BaseResolver
+from yaml.loader import Loader
+
 ESCAPE_CHAR_DICT = {":": "\':\'",
                     "\t": "    "}
+
+
+class LineLoader(Loader):  # pylint: disable=too-many-ancestors
+    """
+    LineLoader parses a yaml into a python dictionary extended with extra items.
+    The new items have as keys __line__<yaml_keyword> and as values the yaml file line number
+    """
+
+    def compose_node(self, parent, index):
+        # the line number where the previous token has ended (plus empty lines)
+        node = Composer.compose_node(self, parent, index)
+        node.__line__ = self.line + 1
+        return node
+
+    def construct_mapping(self, node, deep=False):
+        node_pair_lst = node.value
+        node_pair_lst_for_appending = []
+
+        for key_node in node_pair_lst:
+            shadow_key_node = ScalarNode(
+                tag=BaseResolver.DEFAULT_SCALAR_TAG, value='__line__' + key_node[0].value)
+            shadow_value_node = ScalarNode(
+                tag=BaseResolver.DEFAULT_SCALAR_TAG, value=key_node[0].__line__)
+            node_pair_lst_for_appending.append(
+                (shadow_key_node, shadow_value_node))
+
+        node.value = node_pair_lst + node_pair_lst_for_appending
+        return Constructor.construct_mapping(self, node, deep=deep)
 
 
 def get_yaml_escape_char_dict():
@@ -88,3 +123,24 @@ def cleaning_empty_lines(line_list):
         line_list = line_list[0:-1]
 
     return line_list
+
+
+def nx_name_type_resolving(tmp):
+    """
+    extracts the eventually custom name {optional_string}
+    and type {nexus_type} from a YML section string.
+    YML section string syntax: optional_string(nexus_type)
+    """
+    if tmp.count('(') == 1 and tmp.count(')') == 1:
+        # we can safely assume that every valid YML key resolves
+        # either an nx_ (type, base, candidate) class contains only 1 '(' and ')'
+        index_start = tmp.index('(')
+        index_end = tmp.index(')', index_start + 1)
+        typ = tmp[index_start + 1:index_end]
+        nam = tmp.replace('(' + typ + ')', '')
+        return nam, typ
+
+    # or a name for a member
+    typ = ''
+    nam = tmp
+    return nam, typ

--- a/nexusutils/nyaml2nxdl/nyaml2nxdl_helper.py
+++ b/nexusutils/nyaml2nxdl/nyaml2nxdl_helper.py
@@ -34,8 +34,7 @@ from yaml.nodes import ScalarNode
 from yaml.resolver import BaseResolver
 from yaml.loader import Loader
 
-ESCAPE_CHAR_DICT = {":": "\':\'",
-                    "\t": "    "}
+ESCAPE_CHAR_DICT = {"\t": "    "}
 
 
 class LineLoader(Loader):  # pylint: disable=too-many-ancestors
@@ -67,7 +66,7 @@ class LineLoader(Loader):  # pylint: disable=too-many-ancestors
 
 
 def get_yaml_escape_char_dict():
-    """Get escape char and the way to hide them."""
+    """Get escape char and the way to skip them in yaml."""
     return ESCAPE_CHAR_DICT
 
 

--- a/tests/data/nyaml2nxdl/NXattributes.yaml
+++ b/tests/data/nyaml2nxdl/NXattributes.yaml
@@ -1,4 +1,3 @@
-#test case for attributes
 doc: documentation no. 0
 symbols:
   doc: documentation no. 1
@@ -27,4 +26,3 @@ NXellipsometry_base_draft(my_test_extends):
     definition_local:
       doc: documentation no. 7
       \@version:
-      # EMPTY ATTRIBUTES

--- a/tests/data/nyaml2nxdl/NXcomment_yaml2nxdl.yaml
+++ b/tests/data/nyaml2nxdl/NXcomment_yaml2nxdl.yaml
@@ -1,0 +1,68 @@
+
+category: application
+
+# 1: Pincelli, Rettig, Arora at fhi-berlin.mpg.de, Dobener at hu-berlin.de, 06/2022
+#Draft version of a NeXus application definition for photoemission,
+#It is designed to be extended by other application definitions
+#with higher granularity in the data description.
+
+doc: This is the most general application definition for multidimensional photoelectron spectroscopy.
+# 2: symbols comments: comments here
+symbols:
+# 3: symbols doc comments
+  doc: |
+    symbols doc
+# 4: symbol comments: comments here
+  n_different_temperatures: "Number of different temperature setpoints used in the experiment."
+# 5: symbol comments: comments here
+  n_different_voltages: "Number of different voltage setpoints used in the experiment."
+
+# 6: NXmpes: Test -- documentation
+# NXmpes: Test documentation
+NXmpes:
+  # 7: NXmpes: Test documentation
+  # NXmpes: Test documentation
+   # 8: exists: comment
+
+  (NXentry):
+    exists: recommended
+    # 9: Title comment
+    title:
+    # 10: Group comment
+    start_time(NX_DATE_TIME):
+      doc: "Datetime of the start of the measurement."
+    definition:
+      # 11: version_attribute: comments hrere
+      \@version:
+      enumeration: ["NXmpes"]
+    # 12: Scond comment for Comment NXdata(data)
+
+    # 13: comment nxdata(data): comments
+    # comment nxdata(data): comments
+
+    # 14: Third comment for Comment NXdata(data)
+    (NXdata)data:
+     # 15: comment (energy(link)):
+      energy(link):
+        target: /entry/instrument/fluorescence/energy
+     # 16: comment (data(link)):
+      data(link):
+        target: /entry/instrument/fluorescence/data
+      region_origin(NX_INT):
+        doc: |
+          origin of rectangular region selected for readout
+        # 17: dimensions comments:
+
+        dimensions:
+          # 18: rank comments: comments
+          rank: 1
+          # 19: dim comments:
+          dim: [[1, 2]]
+
+  # 20: File endgin comments
+  # 20: File ending comments
+  # 20: File ending comments
+
+  # 21: File endgin comments
+  # 21: File ending comments
+  # 21: File ending comments

--- a/tests/data/nyaml2nxdl/Ref_NXcomment.yaml
+++ b/tests/data/nyaml2nxdl/Ref_NXcomment.yaml
@@ -1,0 +1,68 @@
+
+category: application
+
+# 1: Pincelli, Rettig, Arora at fhi-berlin.mpg.de, Dobener at hu-berlin.de, 06/2022
+#Draft version of a NeXus application definition for photoemission,
+#It is designed to be extended by other application definitions
+#with higher granularity in the data description.
+
+doc: This is the most general application definition for multidimensional photoelectron spectroscopy.
+# 2: symbols comments: comments here
+symbols:
+# 3: symbols doc comments
+  doc: |
+    symbols doc
+# 4: symbol comments: comments here
+  n_different_temperatures: "Number of different temperature setpoints used in the experiment."
+# 5: symbol comments: comments here
+  n_different_voltages: "Number of different voltage setpoints used in the experiment."
+
+# 6: NXmpes: Test -- documentation
+# NXmpes: Test documentation
+NXmpes:
+  # 7: NXmpes: Test documentation
+  # NXmpes: Test documentation
+
+  # 8: exists: comment
+  (NXentry):
+    exists: recommended
+    # 9: Title comment
+    title:
+    # 10: Group comment
+    start_time(NX_DATE_TIME):
+      doc: "Datetime of the start of the measurement."
+    definition:
+      # 11: version_attribute: comments hrere
+      \@version:
+      enumeration: ["NXmpes"]
+    # 12: Scond comment for Comment NXdata(data)
+
+    # 13: comment nxdata(data): comments
+    # comment nxdata(data): comments
+
+    # 14: Third comment for Comment NXdata(data)
+    (NXdata)data:
+     # 15: comment (energy(link)):
+      energy(link):
+        target: /entry/instrument/fluorescence/energy
+     # 16: comment (data(link)):
+      data(link):
+        target: /entry/instrument/fluorescence/data
+      region_origin(NX_INT):
+        doc: |
+          origin of rectangular region selected for readout
+        # 17: dimensions comments:
+
+        # 18: rank comments: comments
+        dimensions:
+          rank: 1
+          # 19: dim comments:
+          dim: [[1, 2]]
+
+  # 20: File endgin comments
+  # 20: File ending comments
+  # 20: File ending comments
+
+  # 21: File endgin comments
+  # 21: File ending comments
+  # 21: File ending comments

--- a/tests/data/nyaml2nxdl/Ref_NXcomment_yaml2nxdl.nxdl.xml
+++ b/tests/data/nyaml2nxdl/Ref_NXcomment_yaml2nxdl.nxdl.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
+<!--
+# NeXus - Neutron and X-ray Common Data Format
+# 
+# Copyright (C) 2014-2022 NeXus International Advisory Committee (NIAC)
+# 
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# For further information, see http://www.nexusformat.org
+-->
+<!--6: NXmpes: Test -\- documentation
+NXmpes: Test documentation-->
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" name="NXmpes" extends="NXobject" type="group" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+    <!--2: symbols comments: comments here-->
+    <symbols>
+        <!--3: symbols doc comments-->
+        <doc>
+             symbols doc
+        </doc>
+        <!--4: symbol comments: comments here-->
+        <symbol name="n_different_temperatures">
+            <doc>
+                 Number of different temperature setpoints used in the experiment.
+            </doc>
+        </symbol>
+        <!--5: symbol comments: comments here-->
+        <symbol name="n_different_voltages">
+            <doc>
+                 Number of different voltage setpoints used in the experiment.
+            </doc>
+        </symbol>
+    </symbols>
+    <!--1: Pincelli, Rettig, Arora at fhi-berlin.mpg.de, Dobener at hu-berlin.de, 06/2022
+Draft version of a NeXus application definition for photoemission,
+It is designed to be extended by other application definitions
+with higher granularity in the data description.-->
+    <doc>
+         This is the most general application definition for multidimensional
+         photoelectron spectroscopy.
+    </doc>
+    <!--7: NXmpes: Test documentation
+NXmpes: Test documentation
+8: exists: comment-->
+    <group type="NXentry" recommended="true">
+        <!--9: Title comment-->
+        <field name="title"/>
+        <!--10: Group comment-->
+        <field name="start_time" type="NX_DATE_TIME">
+            <doc>
+                 Datetime of the start of the measurement.
+            </doc>
+        </field>
+        <field name="definition">
+            <!--11: version_attribute: comments hrere-->
+            <attribute name="version"/>
+            <enumeration>
+                <item value="NXmpes"/>
+            </enumeration>
+        </field>
+        <!--12: Scond comment for Comment NXdata(data)-->
+        <!--13: comment nxdata(data): comments
+comment nxdata(data): comments-->
+        <!--14: Third comment for Comment NXdata(data)-->
+        <group type="NXdata" name="data">
+            <!--15: comment (energy(link)):-->
+            <link name="energy" target="/entry/instrument/fluorescence/energy"/>
+            <!--16: comment (data(link)):-->
+            <link name="data" target="/entry/instrument/fluorescence/data"/>
+            <field name="region_origin" type="NX_INT">
+                <doc>
+                     origin of rectangular region selected for readout
+                </doc>
+                <!--17: dimensions comments:-->
+                <!--18: rank comments: comments-->
+                <dimensions rank="1">
+                    <!--19: dim comments:-->
+                    <dim index="1" value="2"/>
+                </dimensions>
+            </field>
+        </group>
+    </group>
+    <!--20: File endgin comments
+20: File ending comments
+20: File ending comments-->
+    <!--21: File endgin comments
+21: File ending comments
+21: File ending comments-->
+</definition>

--- a/tests/data/nyaml2nxdl/Ref_NXentry.yaml
+++ b/tests/data/nyaml2nxdl/Ref_NXentry.yaml
@@ -1,50 +1,51 @@
 category: base
-doc: | 
+doc: |
   my nice doc string in root level.
   my nice doc string in root level, line 2.
-
 type: group
 NXentry(NXobject):
   \@default:
-    doc: | 
+    doc: |
       oki
   (NXdata):
-    doc: | 
+    doc: |
       my nice doc string.
             my nice doc string, line 2.
   \@IDF_Version:
-    doc: | 
+    
+    # as ratified at NIAC2010
+    doc: |
       my nice single line doc string
   title:
-    doc: | 
+    doc: |
       Extended title for entry
   collection_description:
-    doc: | 
+    doc: |
       My not very proper doc string, it is supported though
   experiment_identifier:
-    doc: | 
+    doc: |
       My not very proper doc string, it is supported though
          Point-1':'
               my not very proper doc string, line2
       my not very proper doc string, line3
   experiment_description:
-    doc: | 
+    doc: |
       My single line doc string.
   (NXnote)experiment_documentation:
-    doc: | 
+    doc: |
       My single line doc string, with doc tags in different lines
   collection_identifier:
-    doc: | 
+    doc: |
       Yet another doc string not very proper but supported
   entry_identifier_uuid:
-    doc: | 
+    doc: |
       Yet another doc string not very proper but supported
       Yet another doc string not very proper but supported, line2
     \@version:
-      doc: | 
+      doc: |
         Version of UUID used
   entry_identifier:
-    doc: | 
+    doc: |
       Trailing line doc stringy. Trailing lines are removed
   (NXuser):
   (NXsample):

--- a/tests/data/nyaml2nxdl/Ref_NXentry.yaml
+++ b/tests/data/nyaml2nxdl/Ref_NXentry.yaml
@@ -25,7 +25,7 @@ NXentry(NXobject):
   experiment_identifier:
     doc: |
       My not very proper doc string, it is supported though
-         Point-1':'
+         Point-1:
               my not very proper doc string, line2
       my not very proper doc string, line3
   experiment_description:

--- a/tests/nyaml2nxdl/README.md
+++ b/tests/nyaml2nxdl/README.md
@@ -1,4 +1,5 @@
 This is the place for storing code for tests of the yaml2nxdl and nxdl2yaml NeXus schema translation routines.
 
 ## Contact person in FAIRmat for these tests
-Andrea Albino
+1. Rubel Mozumder
+2. Andrea Albino

--- a/tests/nyaml2nxdl/test_nyaml2nxdl.py
+++ b/tests/nyaml2nxdl/test_nyaml2nxdl.py
@@ -287,3 +287,36 @@ has not the same root entries!!'
     os.remove('tests/data/nyaml2nxdl/Ref_NXellipsometry_parsed.yaml')
     os.remove('tests/data/nyaml2nxdl/Ref_NXellipsometry.nxdl.xml')
     sys.stdout.write('Test on yml -> xml -> yml okay.\n')
+
+
+def test_yaml_comment_parsing():
+    """Test comments parsing from yaml. Convert 'yaml' input file to '.nxdl.xml' and
+    '.nxdl.xml' to '.yaml'
+    """
+    from nexusutils.nyaml2nxdl.comment_collector import CommentCollector, Comment
+    from nexusutils.nyaml2nxdl.nyaml2nxdl_helper import LineLoader
+
+    ref_yml_file = 'tests/data/nyaml2nxdl/Ref_NXcomment.yaml'
+    test_yml_file = 'tests/data/nyaml2nxdl/Ref_NXcomment_consistency.yaml'
+
+    result = CliRunner().invoke(nyml2nxdl.launch_tool,
+                                ['--input-file', ref_yml_file,
+                                 '--check-cosistency'])
+    assert result.exit_code == 0, (f'Exception: {result.exception}, \nExecution Info:'
+                                   '{result.exc_info}')
+    with open(ref_yml_file, 'r', encoding='utf-8') as ref_yml:
+        loader = LineLoader(ref_yml)
+        ref_loaded_yaml = loader.get_single_data()
+    ref_comment_blocks = CommentCollector(ref_yml_file, ref_loaded_yaml)
+    ref_comment_blocks.extract_all_comment_blocks()
+
+    with open(test_yml_file, 'r', encoding='utf-8') as test_yml:
+        loader = LineLoader(test_yml)
+        test_loaded_yaml = loader.get_single_data()
+    test_comment_blocks = CommentCollector(ref_yml_file, test_loaded_yaml)
+    test_comment_blocks.extract_all_comment_blocks()
+
+    for ref_cmnt, test_cmnt in zip(ref_comment_blocks, test_comment_blocks):
+        assert ref_cmnt == test_cmnt
+
+    os.remove(test_yml_file)

--- a/tests/nyaml2nxdl/test_nyaml2nxdl.py
+++ b/tests/nyaml2nxdl/test_nyaml2nxdl.py
@@ -278,9 +278,9 @@ def test_yml_parsing():
     assert result.exit_code == 0
     check_file_fresh_baked(test_yml_file)
 
-    test_yml_tree = nyaml2nxdl_forward_tools.yml_reader(test_yml_file)
+    test_yml_tree, _ = nyaml2nxdl_forward_tools.yml_reader(test_yml_file)
 
-    ref_yml_tree = nyaml2nxdl_forward_tools.yml_reader(ref_yml_file)
+    ref_yml_tree, _ = nyaml2nxdl_forward_tools.yml_reader(ref_yml_file)
 
     assert list(test_yml_tree) == list(ref_yml_tree), 'Ref YML and parsed YML \
 has not the same root entries!!'
@@ -289,11 +289,11 @@ has not the same root entries!!'
     sys.stdout.write('Test on yml -> xml -> yml okay.\n')
 
 
-def test_yaml_comment_parsing():
+def test_yml_consistency_comment_parsing():
     """Test comments parsing from yaml. Convert 'yaml' input file to '.nxdl.xml' and
     '.nxdl.xml' to '.yaml'
     """
-    from nexusutils.nyaml2nxdl.comment_collector import CommentCollector, Comment
+    from nexusutils.nyaml2nxdl.comment_collector import CommentCollector
     from nexusutils.nyaml2nxdl.nyaml2nxdl_helper import LineLoader
 
     ref_yml_file = 'tests/data/nyaml2nxdl/Ref_NXcomment.yaml'
@@ -301,7 +301,7 @@ def test_yaml_comment_parsing():
 
     result = CliRunner().invoke(nyml2nxdl.launch_tool,
                                 ['--input-file', ref_yml_file,
-                                 '--check-cosistency'])
+                                 '--check-consistency'])
     assert result.exit_code == 0, (f'Exception: {result.exception}, \nExecution Info:'
                                    '{result.exc_info}')
     with open(ref_yml_file, 'r', encoding='utf-8') as ref_yml:
@@ -313,10 +313,40 @@ def test_yaml_comment_parsing():
     with open(test_yml_file, 'r', encoding='utf-8') as test_yml:
         loader = LineLoader(test_yml)
         test_loaded_yaml = loader.get_single_data()
-    test_comment_blocks = CommentCollector(ref_yml_file, test_loaded_yaml)
+    test_comment_blocks = CommentCollector(test_yml_file, test_loaded_yaml)
     test_comment_blocks.extract_all_comment_blocks()
 
     for ref_cmnt, test_cmnt in zip(ref_comment_blocks, test_comment_blocks):
-        assert ref_cmnt == test_cmnt
+        assert ref_cmnt == test_cmnt, 'Comment is not consistent.'
 
     os.remove(test_yml_file)
+
+
+def test_yml2xml_comment_parsing():
+    """To test comment that written in xml for element attributes, e.g.
+    attribute 'rank' for 'dimension' element and attribute 'exists' for
+    'NXentry' group element.
+    """
+    input_yml = 'tests/data/nyaml2nxdl/NXcomment_yaml2nxdl.yaml'
+    ref_xml = 'tests/data/nyaml2nxdl/Ref_NXcomment_yaml2nxdl.nxdl.xml'
+    test_xml = 'tests/data/nyaml2nxdl/NXcomment_yaml2nxdl.nxdl.xml'
+
+    result = CliRunner().invoke(nyml2nxdl.launch_tool,
+                                ['--input-file', input_yml])
+    assert result.exit_code == 0
+
+    ref_root = ET.parse(ref_xml).getroot()
+    test_root = ET.parse(test_xml).getroot()
+
+    def recursive_compare(ref_root, test_root):
+        assert ref_root.attrib.items() == test_root.attrib.items(), ("Got different xml element"
+                                                                     "Atribute.")
+        if ref_root.text and test_root.text:
+            assert ref_root.text.strip() == test_root.text.strip(), ("Got differen element text.")
+        if len(ref_root) > 0 and len(test_root) > 0:
+            for x, y in zip(ref_root, test_root):
+                recursive_compare(x, y)
+
+    recursive_compare(ref_root, test_root)
+
+    os.remove(test_xml)

--- a/tests/nyaml2nxdl/test_nyaml2nxdl.py
+++ b/tests/nyaml2nxdl/test_nyaml2nxdl.py
@@ -278,9 +278,9 @@ def test_yml_parsing():
     assert result.exit_code == 0
     check_file_fresh_baked(test_yml_file)
 
-    test_yml_tree, _ = nyaml2nxdl_forward_tools.yml_reader(test_yml_file)
+    test_yml_tree = nyaml2nxdl_forward_tools.yml_reader(test_yml_file)
 
-    ref_yml_tree, _ = nyaml2nxdl_forward_tools.yml_reader(ref_yml_file)
+    ref_yml_tree = nyaml2nxdl_forward_tools.yml_reader(ref_yml_file)
 
     assert list(test_yml_tree) == list(ref_yml_tree), 'Ref YML and parsed YML \
 has not the same root entries!!'


### PR DESCRIPTION
The converter `nyaml2nxdl` can now store comments in forward and backward conversion.

One extra class `XMLComment` has already been, albeit it's been not used(instead XML library was exploited), still, it can be used if needed in the future.