### PR TITLE
Ellipsometry reader + mock function

### DIFF
--- a/pynxtools/dataconverter/readers/ellips/mock.py
+++ b/pynxtools/dataconverter/readers/ellips/mock.py
@@ -1,0 +1,157 @@
+# Copyright The NOMAD Authors.
+#
+# This file is part of NOMAD. See https://nomad-lab.eu for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""A generic class for generating duplicate outputs for ellipsometry"""
+from typing import Tuple, Any
+import random
+import numpy as np
+import ase
+from ase.data import chemical_symbols
+from typing import Union
+# from nexusutils.dataconverter.readers.ellips.reader_utils import extract_atom_types
+from pynxtools.dataconverter.helpers import extract_atom_types
+
+
+class MockEllips():
+    """ A generic class for generating duplicate outputs for ELLIPSOMETRY
+
+        Contains:
+        - mock_sample:
+            Chooses random entry from sample_list, overwrites sample_name
+            and extracts atom_types
+        - mock_chemical_formula:
+            Creates a list of chemical formulas consisting of two atom types
+        - modify_spectral_range:
+            Change spectral range (i.e. wavelength array) and step size.
+        - mock_angles:
+            Change value and number of incident angles
+        - choose_data_type:
+            Chooses random entry from data_types
+        - mock_signals:
+            Mock data if data_type is psi/delta or tan(psi)/cos(delta)
+        - mock_Mueller_matrix:
+            Mock data if data_type is Mueller matrix
+        - mock_template:
+            Creates mock ellipsometry data (by calling the above routines)
+    """
+
+    def __init__(self, dict):
+        self.name = dict["sample_name"]
+        self.data_type = dict["data_type"]
+        self.data = dict["measured_data"]
+        self.wavelength = dict["spectrometer/wavelength"]
+        self.atom_types = dict["atom_types"]
+        self.sample_list = []
+        self.data_types = ["psi/delta", "tan(psi)/cos(delta)", "Mueller matrix"]
+        self.angles = []
+        self.number_of_signals = 0
+        self.angle_list = [40, 45, 50, 55, 60, 65, 70, 75, 80]
+
+    def mock_sample(self, dict) -> None:
+        """ Chooses random entry from sample_list, overwrites sample_name
+            and extracts atom_types
+        """
+        self.mock_chemical_formula()
+        self.name = random.choice(self.sample_list)
+        self.atom_types = extract_atom_types(self.name)
+        dict["sample_name"] = self.name
+        dict["atom_types"] = self.atom_types
+        dict["layer_structure"] = f"{self.name} bulk"
+        dict["experiment_description"] = f"RC2 scan on {self.name} bulk"
+
+    def choose_data_type(self, dict) -> None:
+        """ Chooses random entry from data_types
+        """
+        self.data_type = random.choice(self.data_types)
+        dict["data_type"] = self.data_type
+        if self.data_type == "Mueller matrix":
+            self.number_of_signals = 16
+        elif self.data_type == "psi/delta" or self.data_type == "tan(psi)/cos(delta)":
+            self.number_of_signals = 2
+
+    def mock_chemical_formula(self) -> None:
+        """ Creates a list of chemical formulas consisting of two atom types """
+        part_1 = ase.atom.chemical_symbols[1:]
+        part_2 = list(range(2, 20, 1))
+
+        for x in part_1:
+            for y in part_2:
+                for z in part_1:
+                    for k in part_2:
+                        chemical_formula = f"{x}{y}{z}{k}"
+                        if x != z:
+                            self.sample_list.append(chemical_formula)
+
+    def mock_angles(self, dict) -> None:
+        """ Change value and number of incident angles
+        """
+        for index in range(random.randrange(1, 4)):
+            angle = random.choice(self.angle_list)
+            self.angles.append(angle)
+            self.angle_list.remove(angle)
+        self.angles.sort()
+        dict["angle_of_incidence"] = self.angles
+        if self.number_of_signals == 2:
+            self.mock_signals(dict)
+        elif self.number_of_signals == 16:
+            self.mock_Mueller_matrix(dict)
+
+    def mock_signals(self, dict) -> None:
+        """ Mock data if data_type is psi/delta or tan(psi)/cos(delta)
+            considering the (new) number of incident angles
+        """
+        my_numpy_array = np.empty([1,
+                                   1,
+                                   len(self.angles),
+                                   self.number_of_signals,
+                                   len(self.wavelength)
+                                   ])
+        for index in range(0, len(self.angles)):
+            noise = np.random.normal(0, 0.5, self.data[0, 0, 0, 0, :].size)
+            my_numpy_array[0][0][index] = self.data[0][0][0] * random.uniform(0.5, 1.5) + noise
+        self.data = my_numpy_array
+        dict["measured_data"] = my_numpy_array
+
+    def mock_Mueller_matrix(self, dict) -> None:
+        """ Mock data if data_type is Mueller matrix (i.e. 16 elements/signals)
+            considering the (new) number of incident angles
+        """
+        my_numpy_array = np.empty([1,
+                                   1,
+                                   len(self.angles),
+                                   self.number_of_signals,
+                                   len(self.wavelength)
+                                   ])
+        for index in range(0, len(self.angles)):
+            noise = np.random.normal(0, 0.1, self .data[0, 0, 0, 0, :].size)
+            for mm_index in range(1, self.number_of_signals):
+                my_numpy_array[0][0][index][mm_index] = self.data[0][0][0][0] * random.uniform(0.5, 1.5) + noise
+            my_numpy_array[0][0][index][0] = my_numpy_array[0][0][0][0] / my_numpy_array[0][0][0][0]
+        dict["measured_data"] = my_numpy_array
+
+    def modify_spectral_range(self, dict) -> None:
+        """ Change spectral range (i.e. wavlength array) and step size,
+            while length of the wavelength array remains the same.
+        """
+        dict["spectrometer/wavelength"] = random.uniform(0.25, 23) * dict["spectrometer/wavelength"]
+
+    def mock_template(self, dict) -> None:
+        """ Creates a mock ellipsometry template """
+        self.mock_sample(dict)
+        self.modify_spectral_range(dict)
+        self.choose_data_type(dict)
+        self.mock_angles(dict)

--- a/pynxtools/dataconverter/readers/ellips/mock.py
+++ b/pynxtools/dataconverter/readers/ellips/mock.py
@@ -49,9 +49,9 @@ class MockEllips():
         self.data = data_template["measured_data"]
         self.wavelength = data_template["spectrometer/wavelength"]
         self.atom_types = data_template["atom_types"]
-        self.sample_list = []
+        self.sample_list: list = []
         self.data_types = ["psi/delta", "tan(psi)/cos(delta)", "Mueller matrix"]
-        self.angles = []
+        self.angles: list = []
         self.number_of_signals = 0
 
     def mock_sample(self, data_template) -> None:

--- a/pynxtools/dataconverter/readers/ellips/mock.py
+++ b/pynxtools/dataconverter/readers/ellips/mock.py
@@ -131,9 +131,10 @@ class MockEllips():
                                    len(self.wavelength)
                                    ])
         for idx in range(0, len(self.angles)):
-            WN = np.random.normal(0, 0.1, self .data[0, 0, 0, 0, :].size)
-            for MM in range(1, self.number_of_signals):
-                my_numpy_array[0][0][idx][MM] = self.data[0][0][0][0] * random.uniform(.5, 1.) + WN
+            noise = np.random.normal(0, 0.1, self .data[0, 0, 0, 0, :].size)
+            for m_idx in range(1, self.number_of_signals):
+                my_numpy_array[0][0][idx][m_idx] = self.data[0][0][0][0] * random.uniform(.5, 1.)
+                my_numpy_array[0][0][idx][m_idx] += noise
             my_numpy_array[0][0][idx][0] = my_numpy_array[0][0][0][0] / my_numpy_array[0][0][0][0]
         data_template["measured_data"] = my_numpy_array
 

--- a/pynxtools/dataconverter/readers/ellips/mock.py
+++ b/pynxtools/dataconverter/readers/ellips/mock.py
@@ -131,9 +131,9 @@ class MockEllips():
                                    len(self.wavelength)
                                    ])
         for idx in range(0, len(self.angles)):
-            wn = np.random.normal(0, 0.1, self .data[0, 0, 0, 0, :].size)
-            for mm in range(1, self.number_of_signals):
-                my_numpy_array[0][0][idx][mm] = self.data[0][0][0][0] * random.uniform(.5, 1.) + wn
+            WN = np.random.normal(0, 0.1, self .data[0, 0, 0, 0, :].size)
+            for MM in range(1, self.number_of_signals):
+                my_numpy_array[0][0][idx][MM] = self.data[0][0][0][0] * random.uniform(.5, 1.) + WN
             my_numpy_array[0][0][idx][0] = my_numpy_array[0][0][0][0] / my_numpy_array[0][0][0][0]
         data_template["measured_data"] = my_numpy_array
 
@@ -141,7 +141,8 @@ class MockEllips():
         """ Change spectral range (i.e. wavlength array) and step size,
             while length of the wavelength array remains the same.
         """
-        data_template["spectrometer/wavelength"] = random.uniform(0.25, 23) * data_template["spectrometer/wavelength"]
+        temp = random.uniform(0.25, 23)
+        data_template["spectrometer/wavelength"] = temp * data_template["spectrometer/wavelength"]
 
     def mock_template(self, data_template) -> None:
         """ Creates a mock ellipsometry template """

--- a/pynxtools/dataconverter/readers/ellips/reader.py
+++ b/pynxtools/dataconverter/readers/ellips/reader.py
@@ -158,6 +158,7 @@ def header_labels(header):
 
     return labels
 
+
 def mock_function(header):
     """ Mock ellipsometry data
 
@@ -184,9 +185,9 @@ def data_set_dims(whole_data):
     """
     energy = whole_data['type'].astype(str).values.tolist().count("E")
     unique_angles, counts = np.unique(whole_data["angle_of_incidence"
-                                                    ].to_numpy()[0:energy].astype("int64"),
-                                        return_counts=True
-                                        )
+                                                 ].to_numpy()[0:energy].astype("int64"),
+                                      return_counts=True
+                                      )
 
     return unique_angles, counts
 

--- a/pynxtools/dataconverter/readers/ellips/reader.py
+++ b/pynxtools/dataconverter/readers/ellips/reader.py
@@ -142,7 +142,7 @@ def populate_template_dict(header, template):
 
 
 def header_labels(header):
-    """ Define header labels
+    """ Define data labels (column names)
 
     """
 
@@ -157,6 +157,26 @@ def header_labels(header):
                 labels.update({f"m{i}{j}": []})
 
     return labels
+
+
+def mock_function(header):
+    """ Define header labels
+
+    """
+
+    mock_header = MockEllips(header)
+    mock_header.mock_template(header)
+
+    # Defining labels:
+    labels = header_labels(header)
+
+    # Atom types: Convert str to list if atom_types is not a list:
+    if isinstance(header["atom_types"], str):
+        header["atom_types"] = header["atom_types"].split(",")
+
+    header["column_names"] = list(labels.keys())
+
+    return header, labels
 
 
 class EllipsometryReader(BaseReader):
@@ -243,21 +263,16 @@ class EllipsometryReader(BaseReader):
         # Create mocked ellipsometry data template:
         is_mock = True
         if is_mock:
-            mock_header = MockEllips(header)
-            mock_header.mock_template(header)
-
-        # Defining labels:
-        labels = header_labels(header)
+            header, labels = mock_function(header)
+            for angle in enumerate(header["angle_of_incidence"]):
+                for key, val in labels.items():
+                    val.append(f"{key}_{int(angle[1])}deg")
+                index += counts[angle[0]]
+                block_idx.append(index)
 
         # Atom types: Convert str to list if atom_types is not a list:
         if isinstance(header["atom_types"], str):
             header["atom_types"] = header["atom_types"].split(",")
-
-        for angle in enumerate(header["angle_of_incidence"]):
-            for key, val in labels.items():
-                val.append(f"{key}_{int(angle[1])}deg")
-            index += counts[angle[0]]
-            block_idx.append(index)
 
         header["column_names"] = list(labels.keys())
 

--- a/pynxtools/dataconverter/readers/ellips/reader.py
+++ b/pynxtools/dataconverter/readers/ellips/reader.py
@@ -235,12 +235,12 @@ class EllipsometryReader(BaseReader):
                                    counts[0]
                                    ])
 
-        for index, unique_angle in enumerate(unique_angles):
+        for index, angle in enumerate(unique_angles):
             my_numpy_array[0,
                            0,
                            index,
                            :,
-                           :] = unique_angle
+                           :] = angle
         data_index = 0
         for key, val in labels.items():
             for index in range(len(val)):

--- a/pynxtools/dataconverter/readers/ellips/reader.py
+++ b/pynxtools/dataconverter/readers/ellips/reader.py
@@ -185,9 +185,9 @@ class EllipsometryReader(BaseReader):
             labels = {"tan(psi)": [], "cos(delta)": []}
         else:
             labels = {}
-            for i in range(1, 5):
+            for index in range(1, 5):
                 for j in range(1, 5):
-                    temp = {f"m{i}{j}": []}
+                    temp = {f"m{index}{j}": []}
                     labels.update(temp)
 
         block_idx = [np.int64(0)]

--- a/pynxtools/dataconverter/readers/ellips/reader.py
+++ b/pynxtools/dataconverter/readers/ellips/reader.py
@@ -269,7 +269,7 @@ class EllipsometryReader(BaseReader):
         header["angle_of_incidence"] = unique_angles
 
         # Create mocked ellipsometry data template:
-        is_mock = False
+        is_mock = True
         if is_mock:
             header, labels = mock_function(header)
             for angle in enumerate(header["angle_of_incidence"]):

--- a/pynxtools/dataconverter/readers/ellips/reader.py
+++ b/pynxtools/dataconverter/readers/ellips/reader.py
@@ -183,7 +183,7 @@ class EllipsometryReader(BaseReader):
             labels = {"psi": [], "delta": []}
         elif header["data_type"] == "tan(psi)/cos(delta)":
             labels = {"tan(psi)": [], "cos(delta)": []}
-        elif header["data_type"] == "Mueller matrix":
+        else:
             labels = {}
             for i in range(1, 5):
                 for j in range(1, 5):
@@ -193,7 +193,7 @@ class EllipsometryReader(BaseReader):
         block_idx = [np.int64(0)]
         index = 0
         for angle in enumerate(unique_angles):
-            for key in labels.keys():
+            for key in labels:
                 labels[key].append(f"{key}_{int(angle[1])}deg")
             index += counts[angle[0]]
             block_idx.append(index)
@@ -213,7 +213,7 @@ class EllipsometryReader(BaseReader):
                            :,
                            :] = unique_angle
         data_index = 0
-        for key, val in labels.items():
+        for key in labels:
             for index in range(len(labels[key])):
                 my_numpy_array[0,
                                0,
@@ -254,7 +254,7 @@ class EllipsometryReader(BaseReader):
                     labels_new.update(temp)
 
         for angle in enumerate(header["angle_of_incidence"]):
-            for key in labels_new.keys():
+            for key in labels_new:
                 labels_new[key].append(f"{key}_{int(angle[1])}deg")
             index += counts[angle[0]]
             block_idx.append(index)

--- a/pynxtools/dataconverter/readers/ellips/reader.py
+++ b/pynxtools/dataconverter/readers/ellips/reader.py
@@ -232,8 +232,7 @@ class EllipsometryReader(BaseReader):
         header["angle_of_incidence"] = unique_angles
 
         # Create mocked ellipsometry data template:
-        is_mock = True
-        if is_mock:
+        if True:
             mock_header = MockEllips(header)
             mock_header.mock_template(header)
 
@@ -243,25 +242,25 @@ class EllipsometryReader(BaseReader):
 
         # Defining labels:
         if header["data_type"] == "psi/delta":
-            labels_new = {"psi": [], "delta": []}
+            labels = {"psi": [], "delta": []}
         elif header["data_type"] == "tan(psi)/cos(delta)":
-            labels_new = {"tan(psi)": [], "cos(delta)": []}
-        elif header["data_type"] == "Mueller matrix":
-            labels_new = {}
+            labels = {"tan(psi)": [], "cos(delta)": []}
+        else:
+            labels = {}
             for i in range(1, 5):
                 for j in range(1, 5):
                     temp = {f"m{i}{j}": []}
-                    labels_new.update(temp)
+                    labels.update(temp)
 
         for angle in enumerate(header["angle_of_incidence"]):
-            for key in labels_new:
-                labels_new[key].append(f"{key}_{int(angle[1])}deg")
+            for key in labels:
+                labels[key].append(f"{key}_{int(angle[1])}deg")
             index += counts[angle[0]]
             block_idx.append(index)
 
-        header["column_names"] = list(labels_new.keys())
+        header["column_names"] = list(labels.keys())
 
-        return header, labels_new
+        return header, labels
 
     def read(self,
              template: dict = None,

--- a/pynxtools/dataconverter/readers/ellips/reader.py
+++ b/pynxtools/dataconverter/readers/ellips/reader.py
@@ -141,6 +141,24 @@ def populate_template_dict(header, template):
     return template
 
 
+def header_labels(header):
+    """ Define header labels
+
+    """
+
+    if header["data_type"] == "psi/delta":
+        labels = {"psi": [], "delta": []}
+    elif header["data_type"] == "tan(psi)/cos(delta)":
+        labels = {"tan(psi)": [], "cos(delta)": []}
+    else:
+        labels = {}
+        for i in range(1, 5):
+            for j in range(1, 5):
+                labels.update({f"m{i}{j}": []})
+
+    return labels
+
+
 class EllipsometryReader(BaseReader):
     """An example reader implementation for the DataConverter.
     Importing metadata from the yaml file based on the last
@@ -179,15 +197,7 @@ class EllipsometryReader(BaseReader):
                                           return_counts=True
                                           )
 
-        if header["data_type"] == "psi/delta":
-            labels = {"psi": [], "delta": []}
-        elif header["data_type"] == "tan(psi)/cos(delta)":
-            labels = {"tan(psi)": [], "cos(delta)": []}
-        else:
-            labels = {}
-            for i in range(1, 5):
-                for j in range(1, 5):
-                    labels.update({f"m{i}{j}": []})
+        labels = header_labels(header)
 
         block_idx = [np.int64(0)]
         index = 0
@@ -237,15 +247,7 @@ class EllipsometryReader(BaseReader):
             mock_header.mock_template(header)
 
         # Defining labels:
-        if header["data_type"] == "psi/delta":
-            labels = {"psi": [], "delta": []}
-        elif header["data_type"] == "tan(psi)/cos(delta)":
-            labels = {"tan(psi)": [], "cos(delta)": []}
-        else:
-            labels = {}
-            for i in range(1, 5):
-                for j in range(1, 5):
-                    labels.update({f"m{i}{j}": []})
+        labels = header_labels(header)
 
         # Atom types: Convert str to list if atom_types is not a list:
         if isinstance(header["atom_types"], str):

--- a/pynxtools/dataconverter/readers/ellips/reader.py
+++ b/pynxtools/dataconverter/readers/ellips/reader.py
@@ -158,9 +158,8 @@ def header_labels(header):
 
     return labels
 
-
 def mock_function(header):
-    """ Define header labels
+    """ Mock ellipsometry data
 
     """
 
@@ -177,6 +176,19 @@ def mock_function(header):
     header["column_names"] = list(labels.keys())
 
     return header, labels
+
+
+def data_set_dims(whole_data):
+    """ User defined variables to produce slices of the whole data set
+
+    """
+    energy = whole_data['type'].astype(str).values.tolist().count("E")
+    unique_angles, counts = np.unique(whole_data["angle_of_incidence"
+                                                    ].to_numpy()[0:energy].astype("int64"),
+                                        return_counts=True
+                                        )
+
+    return unique_angles, counts
 
 
 class EllipsometryReader(BaseReader):
@@ -210,12 +222,7 @@ class EllipsometryReader(BaseReader):
             # this we have tried, we should throw an error...
             whole_data = load_as_pandas_array(header["filename"], header)
 
-        # User defined variables to produce slices of the whole data set
-        energy = whole_data['type'].astype(str).values.tolist().count("E")
-        unique_angles, counts = np.unique(whole_data["angle_of_incidence"
-                                                     ].to_numpy()[0:energy].astype("int64"),
-                                          return_counts=True
-                                          )
+        unique_angles, counts = data_set_dims(whole_data)
 
         labels = header_labels(header)
 
@@ -261,7 +268,7 @@ class EllipsometryReader(BaseReader):
         header["angle_of_incidence"] = unique_angles
 
         # Create mocked ellipsometry data template:
-        is_mock = True
+        is_mock = False
         if is_mock:
             header, labels = mock_function(header)
             for angle in enumerate(header["angle_of_incidence"]):

--- a/pynxtools/dataconverter/readers/ellips/reader.py
+++ b/pynxtools/dataconverter/readers/ellips/reader.py
@@ -23,6 +23,7 @@ import pandas as pd
 import numpy as np
 # import h5py
 from pynxtools.dataconverter.readers.base.reader import BaseReader
+from pynxtools.dataconverter.readers.ellips.mock import MockEllips
 
 DEFAULT_HEADER = {'sep': '\t', 'skip': 0}
 
@@ -38,6 +39,7 @@ def load_header(filename, default):
         Returns:
             a dict containing the loaded information
     """
+
     with open(filename, 'rt', encoding='utf8') as file:
         header = yaml.safe_load(file)
 
@@ -141,10 +143,9 @@ def populate_template_dict(header, template):
 
 class EllipsometryReader(BaseReader):
     """An example reader implementation for the DataConverter.
-
-Importing metadata from the yaml file based on the last
-two parts of the key in the application definition.
-"""
+    Importing metadata from the yaml file based on the last
+    two parts of the key in the application definition.
+    """
 
     # Whitelist for the NXDLs that the reader supports and can process
     supported_nxdls = ["NXellipsometry"]
@@ -153,16 +154,16 @@ two parts of the key in the application definition.
     def populate_header_dict_with_datasets(file_paths):
         """This is an ellipsometry-specific processing of data.
 
-    The procedure is the following:
-    - the header dictionary is initialized reading a yaml file
-    - the data are read from header["filename"] and saved in a pandas object
-    - an array is shaped according to application definition in a 5D array (numpy array)
-    - the array is saved in a HDF5 file as a dataset
-    - virtual datasets instances are created in the header dictionary,
-      referencing to data in the created HDF5 file.
-    - the header is finally returned, ready to be parsed in the final template dictionary
+        The procedure is the following:
+        - the header dictionary is initialized reading a yaml file
+        - the data are read from header["filename"] and saved in a pandas object
+        - an array is shaped according to application definition in a 5D array (numpy array)
+        - the array is saved in a HDF5 file as a dataset
+        - virtual datasets instances are created in the header dictionary,
+        referencing to data in the created HDF5 file.
+        - the header is finally returned, ready to be parsed in the final template dictionary
 
-    """
+        """
         header, data_file = populate_header_dict(file_paths)
 
         if os.path.isfile(data_file):
@@ -177,21 +178,31 @@ two parts of the key in the application definition.
                                                      ].to_numpy()[0:energy].astype("int64"),
                                           return_counts=True
                                           )
-        labels = {"psi": [], "delta": []}
+
+        if header["data_type"] == "psi/delta":
+            labels = {"psi": [], "delta": []}
+        elif header["data_type"] == "tan(psi)/cos(delta)":
+            labels = {"tan(psi)": [], "cos(delta)": []}
+        elif header["data_type"] == "Mueller matrix":
+            labels = {}
+            for i in range(1, 5):
+                for j in range(1, 5):
+                    temp = {f"m{i}{j}": []}
+                    labels.update(temp)
+
         block_idx = [np.int64(0)]
         index = 0
         for angle in enumerate(unique_angles):
-            labels["psi"].append(f"psi_{int(angle[1])}deg")
-            labels["delta"].append(f"delta_{int(angle[1])}deg")
+            for key in labels.keys():
+                labels[key].append(f"{key}_{int(angle[1])}deg")
             index += counts[angle[0]]
             block_idx.append(index)
 
         # array that will be allocated in a HDF5 file
-        # counts[0] = N_wavelents*N_time*N_p1
         my_numpy_array = np.empty([1,
                                    1,
                                    len(unique_angles),
-                                   len(['psi', 'delta']),
+                                   len(labels),
                                    counts[0]
                                    ])
 
@@ -201,30 +212,56 @@ two parts of the key in the application definition.
                            index,
                            :,
                            :] = unique_angle
-
-        for index in range(len(labels["psi"])):
-            my_numpy_array[0,
-                           0,
-                           index,
-                           0,
-                           :] = whole_data["psi"].to_numpy()[block_idx[index]:block_idx[index + 1]
-                                                             ].astype("float64")
-
-        for index in range(len(labels["delta"])):
-            my_numpy_array[0,
-                           0,
-                           index,
-                           1,
-                           :] = whole_data["delta"].to_numpy()[block_idx[index]:block_idx[index + 1]
+        data_index = 0
+        for key, val in labels.items():
+            for index in range(len(labels[key])):
+                my_numpy_array[0,
+                               0,
+                               index,
+                               data_index,
+                               :] = whole_data[key].to_numpy()[block_idx[index]:block_idx[index + 1]
                                                                ].astype("float64")
+            data_index += 1
 
         # measured_data is a required field
         header["measured_data"] = my_numpy_array
         header["spectrometer/wavelength"] = (
             whole_data["wavelength"].to_numpy()[0:counts[0]].astype("float64")
         )
+
         header["angle_of_incidence"] = unique_angles
-        return header, labels["psi"], labels["delta"]
+
+        # Create mocked ellipsometry data template:
+        is_mock = True
+        if is_mock:
+            mock_header = MockEllips(header)
+            mock_header.mock_template(header)
+
+        # Atom types: Convert str to list if atom_types is not a list:
+        if isinstance(header["atom_types"], str):
+            header["atom_types"] = header["atom_types"].split(",")
+
+        # Defining labels:
+        if header["data_type"] == "psi/delta":
+            labels_new = {"psi": [], "delta": []}
+        elif header["data_type"] == "tan(psi)/cos(delta)":
+            labels_new = {"tan(psi)": [], "cos(delta)": []}
+        elif header["data_type"] == "Mueller matrix":
+            labels_new = {}
+            for i in range(1, 5):
+                for j in range(1, 5):
+                    temp = {f"m{i}{j}": []}
+                    labels_new.update(temp)
+
+        for angle in enumerate(header["angle_of_incidence"]):
+            for key in labels_new.keys():
+                labels_new[key].append(f"{key}_{int(angle[1])}deg")
+            index += counts[angle[0]]
+            block_idx.append(index)
+
+        header["column_names"] = list(labels_new.keys())
+
+        return header, labels_new
 
     def read(self,
              template: dict = None,
@@ -245,9 +282,13 @@ two parts of the key in the application definition.
             raise Exception("No input files were given to Ellipsometry Reader.")
 
         # The header dictionary is filled with entries.
-        header, psilist, deltalist = (
+        header, labels = (
             EllipsometryReader.populate_header_dict_with_datasets(file_paths)
         )
+
+        data_list = []
+        for val in labels.values():
+            data_list.append(val)
 
         # The template dictionary is filled
         template = populate_template_dict(header, template)
@@ -255,33 +296,26 @@ two parts of the key in the application definition.
         template["/ENTRY[entry]/plot/wavelength"] = {"link":
                                                      "/entry/instrument/spectrometer/wavelength"
                                                      }
-        template["/ENTRY[entry]/plot/wavelength/@units"] = "angstrom"
-
-        for index, psi in enumerate(psilist):
-            template[f"/ENTRY[entry]/plot/{psi}"] = {"link":
-                                                     "/entry/sample/measured_data",
-                                                     "shape":
-                                                     np.index_exp[0, 0, index, 0, :]
-                                                     }
-            template[f"/ENTRY[entry]/plot/{psi}/@units"] = "degrees"
-
-        for index, delta in enumerate(deltalist):
-            template[f"/ENTRY[entry]/plot/{delta}"] = {"link":
-                                                       "/entry/sample/measured_data",
-                                                       "shape":
-                                                       np.index_exp[0, 0, index, 1, :]
-                                                       }
-            template[f"/ENTRY[entry]/plot/{delta}/@units"] = "degrees"
+        template["/ENTRY[entry]/plot/wavelength/@units"] = header["wavelength_unit"]
+        for data_indx in range(0, len(labels.keys())):
+            for index, key in enumerate(data_list[data_indx]):
+                template[f"/ENTRY[entry]/plot/{key}"] = {"link":
+                                                         "/entry/sample/measured_data",
+                                                         "shape":
+                                                         np.index_exp[0, 0, index, data_indx, :]
+                                                         }
+                template[f"/ENTRY[entry]/plot/{key}/@units"] = "degrees"
 
         # Define default plot showing psi and delta at all angles:
         template["/@default"] = "entry"
         template["/ENTRY[entry]/@default"] = "plot"
-        template["/ENTRY[entry]/plot/@signal"] = f"{psilist[0]}"
+        template["/ENTRY[entry]/plot/@signal"] = f"{data_list[0][0]}"
         template["/ENTRY[entry]/plot/@axes"] = "wavelength"
-        if len(psilist) > 1:
-            template["/ENTRY[entry]/plot/@auxiliary_signals"] = psilist[1:] + deltalist
-        else:
-            template["/ENTRY[entry]/plot/@auxiliary_signals"] = deltalist
+
+        # if len(data_list[0]) > 1:
+        template["/ENTRY[entry]/plot/@auxiliary_signals"] = data_list[0][1:]
+        for index in range(1, len(data_list)):
+            template["/ENTRY[entry]/plot/@auxiliary_signals"] += data_list[index]
 
         return template
 

--- a/pynxtools/dataconverter/readers/ellips/reader.py
+++ b/pynxtools/dataconverter/readers/ellips/reader.py
@@ -185,16 +185,15 @@ class EllipsometryReader(BaseReader):
             labels = {"tan(psi)": [], "cos(delta)": []}
         else:
             labels = {}
-            for index in range(1, 5):
+            for i in range(1, 5):
                 for j in range(1, 5):
-                    temp = {f"m{index}{j}": []}
-                    labels.update(temp)
+                    labels.update({f"m{i}{j}": []})
 
         block_idx = [np.int64(0)]
         index = 0
         for angle in enumerate(unique_angles):
-            for key in labels:
-                labels[key].append(f"{key}_{int(angle[1])}deg")
+            for key, val in labels.items():
+                val.append(f"{key}_{int(angle[1])}deg")
             index += counts[angle[0]]
             block_idx.append(index)
 
@@ -213,8 +212,8 @@ class EllipsometryReader(BaseReader):
                            :,
                            :] = unique_angle
         data_index = 0
-        for key in labels:
-            for index in range(len(labels[key])):
+        for key, val in labels.items():
+            for index in range(len(val)):
                 my_numpy_array[0,
                                0,
                                index,
@@ -232,13 +231,10 @@ class EllipsometryReader(BaseReader):
         header["angle_of_incidence"] = unique_angles
 
         # Create mocked ellipsometry data template:
-        if True:
+        is_mock = True
+        if is_mock:
             mock_header = MockEllips(header)
             mock_header.mock_template(header)
-
-        # Atom types: Convert str to list if atom_types is not a list:
-        if isinstance(header["atom_types"], str):
-            header["atom_types"] = header["atom_types"].split(",")
 
         # Defining labels:
         if header["data_type"] == "psi/delta":
@@ -249,12 +245,15 @@ class EllipsometryReader(BaseReader):
             labels = {}
             for i in range(1, 5):
                 for j in range(1, 5):
-                    temp = {f"m{i}{j}": []}
-                    labels.update(temp)
+                    labels.update({f"m{i}{j}": []})
+
+        # Atom types: Convert str to list if atom_types is not a list:
+        if isinstance(header["atom_types"], str):
+            header["atom_types"] = header["atom_types"].split(",")
 
         for angle in enumerate(header["angle_of_incidence"]):
-            for key in labels:
-                labels[key].append(f"{key}_{int(angle[1])}deg")
+            for key, val in labels.items():
+                val.append(f"{key}_{int(angle[1])}deg")
             index += counts[angle[0]]
             block_idx.append(index)
 


### PR DESCRIPTION
Changes in ellips reader:

- Optional use of mock function for ellipsometry data
- Automatic labelling of data labelsdepending on data type and angle of incidence
- Writing atom_types as list (if entered as string in eln_data.yaml)

Mock function:

- random atom types, chemical formula and sample name
- modifies spectral range, incident angles
- random choice of data type (psi/Delta, tan(psi)/cos(delta), Mueller matrix)
- distorts data + adds noise to data